### PR TITLE
Sample(openssl-hook): use `LD_PRELOAD` hook openssl lib to support `rats-rs` anywhere use openssl lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccaf7e9dfbb6ab22c82e473cd1a8a7bd313c19a5b7e40970f3d89ef5a5c9e81e"
+dependencies = [
+ "unicode-width",
+ "yansi-term",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,6 +189,7 @@ version = "0.65.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
 dependencies = [
+ "annotate-snippets",
  "bitflags 1.3.2",
  "cexpr",
  "clang-sys",
@@ -1033,6 +1044,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "openssl-sys"
+version = "0.9.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+dependencies = [
+ "bindgen 0.65.1",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,6 +1138,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "powerfmt"
@@ -1215,6 +1245,7 @@ dependencies = [
  "log",
  "maybe-async",
  "occlum_dcap",
+ "openssl-sys",
  "p256",
  "pkcs8",
  "rand",
@@ -1754,6 +1785,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1984,6 +2021,15 @@ dependencies = [
  "bitflags 2.5.0",
  "rustversion",
  "volatile",
+]
+
+[[package]]
+name = "yansi-term"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/examples/openssl_hook/Cargo.toml
+++ b/examples/openssl_hook/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "openssl_hook"
+edition.workspace = true
+version.workspace = true
+readme.workspace = true
+license.workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+ctor = "0.2.8"
+log = {workspace = true}
+env_logger = {workspace = true}
+libc = "0.2"
+anyhow = {workspace = true}
+lazy_static = "1.5"
+rats-rs = {path = "../../rats-rs", features = ["is-sync"]}

--- a/examples/openssl_hook/README.md
+++ b/examples/openssl_hook/README.md
@@ -1,0 +1,89 @@
+# openssl-hook
+
+A helper library for embedding rats-rs into a programs without recompiling it from source code, with the help of `LD_PRELOAD`. 
+
+## How to use
+
+We have tested it with `curl` and `nginx`.
+
+### nginx
+
+In a TD VM, we launch a simple nginx server which holds a default page, with https enabled.
+
+Note that rats-rs should be compiled in `tdx` mode.
+
+```sh
+# create a nginx configuration file, and save it as ~/nginx.conf
+cat <<EOF > ~/nginx.conf
+daemon off;
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log /var/log/nginx/access.log main;
+
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 5m;
+    ssl_ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256;
+
+    server {
+        listen 1234 ssl;
+        server_name your_domain.com;
+
+        # please place a dump cert and private key files in this location, our hook will replace this with its own files.  
+        ssl_certificate /root/cert.pem;
+        ssl_certificate_key /root/key.pem;
+
+        # rest of your server configuration
+    }
+}
+EOF
+
+# launch the nginx server
+LD_PRELOAD=/root/rats-rs/target/debug/libopenssl_hook.so nginx -c ~/nginx.conf
+```
+
+### curl
+
+Here is the client side, no TEE is required, so you can compile rats-rs with `host` mode.
+
+```sh
+LD_PRELOAD=/root/rats-rs/target/debug/libopenssl_hook.so curl --resolve rats-rs:1234:172.17.0.2 https://rats-rs:1234/
+```
+
+> In the current implementation, the CN field is always `rats-rs`. However, the curl would compare `CN` field in cert with hostname in url. Here we use `--resolve rats-rs:1234:<nginx_ip_address>` to bypass the check from curl. 
+
+## Debug
+
+You can use `gdb` to to debug this library.
+
+```sh
+gdb --args env LD_PRELOAD=/usr/share/rats-rs/samples/libopenssl-hook_lib.so <your-target-app>
+```
+
+You can use `ltrace` to trace openssl 
+```sh
+LD_PRELOAD=/root/rats-rs/target/debug/libopenssl_hook.so ltrace -e "SSL_*" <your-target-app>
+```
+
+## Noted 
+1. your target program may be stuck at setting certificate for a while since it takes time for `rats-rs` to generate a certificate. 
+2. openssl-hook hook **ENTIRE** certificate verify procedure to adapt as many executables, care should be taken if your target app also changes the verify callback.

--- a/examples/openssl_hook/src/lib.rs
+++ b/examples/openssl_hook/src/lib.rs
@@ -1,0 +1,585 @@
+use anyhow::{Error, Result};
+use ctor::{ctor, dtor};
+use lazy_static::lazy_static;
+use libc::*;
+use log::{error, info};
+use rats_rs::cert::create::CertBuilder;
+use rats_rs::crypto::{AsymmetricAlgo, HashAlgo};
+use rats_rs::transport::tls::*;
+use rats_rs::{crypto::DefaultCrypto, tee::AutoAttester};
+use std::ptr::null_mut;
+use std::{ffi::CStr, mem::transmute_copy};
+
+#[derive(Default)]
+struct OsslCtx {
+    ssl_ctx_set_verify: Option<
+        unsafe extern "C" fn(ctx: *mut SSL_CTX, mode: ::libc::c_int, callback: SSL_verify_cb),
+    >,
+    ssl_set_verify:
+        Option<unsafe extern "C" fn(s: *mut SSL, mode: ::libc::c_int, callback: SSL_verify_cb)>,
+    ssl_accept: Option<unsafe extern "C" fn(ssl: *mut SSL) -> ::libc::c_int>,
+    ssl_connect: Option<unsafe extern "C" fn(ssl: *mut SSL) -> ::libc::c_int>,
+    ssl_use_certificate_asn1: Option<
+        unsafe extern "C" fn(
+            ssl: *mut SSL,
+            d: *const ::libc::c_uchar,
+            len: ::libc::c_int,
+        ) -> ::libc::c_int,
+    >,
+    ssl_use_privatekey_asn1: Option<
+        unsafe extern "C" fn(pk: c_int, ssl: *mut SSL, d: *const c_uchar, len: c_long) -> c_int,
+    >,
+    ssl_ctx_use_privatekey_asn1: Option<
+        unsafe extern "C" fn(
+            pk: ::libc::c_int,
+            ctx: *mut SSL_CTX,
+            d: *const ::libc::c_uchar,
+            len: ::libc::c_long,
+        ) -> ::libc::c_int,
+    >,
+    ssl_ctx_use_certificate_asn1: Option<
+        unsafe extern "C" fn(
+            ctx: *mut SSL_CTX,
+            len: ::libc::c_int,
+            d: *const ::libc::c_uchar,
+        ) -> ::libc::c_int,
+    >,
+    ssl_ctx_set_cert_verify_callback: Option<
+        unsafe extern "C" fn(
+            ctx: *mut SSL_CTX,
+            cb: ::std::option::Option<
+                unsafe extern "C" fn(
+                    arg1: *mut X509_STORE_CTX,
+                    arg2: *mut ::libc::c_void,
+                ) -> ::libc::c_int,
+            >,
+            arg: *mut ::libc::c_void,
+        ),
+    >,
+}
+
+// Only update once
+unsafe impl Sync for OsslCtx {}
+
+lazy_static! {
+    static ref OSSL_CTX: OsslCtx = {
+        let ctx = init_openssl_ctx();
+        if let Err(e) = ctx {
+            error!("Failed to fetch openssl symbol! Error: {:?}", e);
+            return OsslCtx::default();
+        }
+        return ctx.unwrap();
+    };
+}
+
+#[inline]
+fn dlsym_load<T: Sized>(name_str: &CStr) -> Result<T> {
+    unsafe {
+        dlerror();
+        let f = dlsym(RTLD_NEXT, name_str.as_ptr());
+        let e = dlerror();
+        if !e.is_null() {
+            return Err(Error::msg(format!(
+                "Failed to find symbol with dlsym {}: {}",
+                name_str.to_str().unwrap(),
+                CStr::from_ptr(e).to_str().unwrap(),
+            )));
+        }
+        if f.is_null() {
+            return Err(Error::msg(format!(
+                "Symbol not resolved by dlsym {}",
+                name_str.to_str().unwrap(),
+            )));
+        }
+        Ok(transmute_copy(&f))
+    }
+}
+
+fn init_openssl_ctx() -> Result<OsslCtx> {
+    let mut ctx = OsslCtx::default();
+    ctx.ssl_accept = Some(dlsym_load(c"SSL_accept")?);
+    ctx.ssl_connect = Some(dlsym_load(c"SSL_connect")?);
+    ctx.ssl_set_verify = Some(dlsym_load(c"SSL_set_verify")?);
+    ctx.ssl_ctx_set_verify = Some(dlsym_load(c"SSL_CTX_set_verify")?);
+    ctx.ssl_ctx_use_certificate_asn1 = Some(dlsym_load(c"SSL_CTX_use_certificate_ASN1")?);
+    ctx.ssl_ctx_use_privatekey_asn1 = Some(dlsym_load(c"SSL_CTX_use_PrivateKey_ASN1")?);
+    ctx.ssl_use_privatekey_asn1 = Some(dlsym_load(c"SSL_use_PrivateKey_ASN1")?);
+    ctx.ssl_use_certificate_asn1 = Some(dlsym_load(c"SSL_use_certificate_ASN1")?);
+    ctx.ssl_ctx_set_cert_verify_callback = Some(dlsym_load(c"SSL_CTX_set_cert_verify_callback")?);
+    Ok(ctx)
+}
+
+fn setup_verifier_with_openssl_ssl_ctx_obj(ctx: *mut SSL_CTX) -> c_int {
+    if let Err(e) = setup_ssl_verifier(OsslObject::SslCtx(ctx)) {
+        error!("setup_verifier_with_openssl_ssl_ctx_obj failed: {:?}", e);
+        return 0;
+    }
+    return 1;
+}
+
+fn setup_verifier_with_openssl_ssl_obj(ssl: *mut SSL) -> c_int {
+    if let Err(e) = setup_ssl_verifier(OsslObject::Ssl(ssl)) {
+        error!("setup_verifier_with_openssl_ssl_obj failed: {:?}", e);
+        return 0;
+    }
+    return 1;
+}
+
+fn setup_attester_with_openssl_ssl_ctx_obj(ctx: *mut SSL_CTX) -> c_int {
+    if let Err(e) = setup_ssl_attester(OsslObject::SslCtx(ctx)) {
+        error!("setup_attester_with_openssl_ssl_ctx_obj failed: {:?}", e);
+        return 0;
+    }
+    return 1;
+}
+
+fn setup_attester_with_openssl_ssl_obj(ssl: *mut SSL) -> c_int {
+    if let Err(e) = setup_ssl_attester(OsslObject::Ssl(ssl)) {
+        error!("setup_attester_with_openssl_ssl_obj failed: {:?}", e);
+        return 0;
+    }
+    return 1;
+}
+
+#[allow(non_snake_case, unused)]
+#[no_mangle]
+pub extern "C" fn SSL_CTX_set_verify(
+    ctx: *mut SSL_CTX,
+    mode: c_int,
+    verify_callback: SSL_verify_cb,
+) {
+    info!("SSL_CTX_set_verify() called");
+    unsafe { OSSL_CTX.ssl_ctx_set_verify.unwrap()(ctx, mode, verify_callback) };
+    setup_verifier_with_openssl_ssl_ctx_obj(ctx);
+}
+
+#[allow(non_snake_case, unused)]
+#[no_mangle]
+pub extern "C" fn SSL_set_verify(ssl: *mut SSL, mode: c_int, verify_callback: SSL_verify_cb) {
+    info!("SSL_set_verify() called");
+    unsafe { OSSL_CTX.ssl_set_verify.unwrap()(ssl, mode, verify_callback) };
+    setup_verifier_with_openssl_ssl_obj(ssl);
+}
+
+#[allow(non_snake_case, unused)]
+#[no_mangle]
+pub extern "C" fn SSL_accept(ssl: *mut SSL) -> c_int {
+    info!("SSL_accept() called");
+    setup_verifier_with_openssl_ssl_obj(ssl);
+    return unsafe { OSSL_CTX.ssl_accept.unwrap()(ssl) };
+}
+
+#[allow(non_snake_case, unused)]
+#[no_mangle]
+extern "C" fn SSL_connect(ssl: *mut SSL) -> c_int {
+    info!("SSL_connect() called");
+    setup_verifier_with_openssl_ssl_obj(ssl);
+    return unsafe { OSSL_CTX.ssl_accept.unwrap()(ssl) };
+}
+
+#[allow(non_snake_case, unused)]
+#[no_mangle]
+pub extern "C" fn SSL_CTX_use_certificate(ctx: *mut SSL_CTX, x: *mut X509) -> c_int {
+    info!("SSL_CTX_use_certificate called");
+    return setup_attester_with_openssl_ssl_ctx_obj(ctx);
+}
+
+#[allow(non_snake_case, unused)]
+#[no_mangle]
+pub extern "C" fn SSL_CTX_use_certificate_ASN1(
+    ctx: *mut SSL_CTX,
+    len: c_int,
+    d: *const c_uchar,
+) -> c_int {
+    info!("SSL_CTX_use_certificate_ASN1");
+    return setup_attester_with_openssl_ssl_ctx_obj(ctx);
+}
+
+#[allow(non_snake_case, unused)]
+#[no_mangle]
+pub extern "C" fn SSL_CTX_use_certificate_file(
+    ctx: *mut SSL_CTX,
+    file: *const c_char,
+    type_: c_int,
+) -> c_int {
+    info!("SSL_CTX_use_certificate_file");
+    return setup_attester_with_openssl_ssl_ctx_obj(ctx);
+}
+
+#[allow(non_snake_case, unused)]
+#[no_mangle]
+pub extern "C" fn SSL_use_certificate(ssl: *mut SSL, x: *mut X509) -> c_int {
+    info!("SSL_use_certificate");
+    return setup_attester_with_openssl_ssl_obj(ssl);
+}
+
+#[allow(non_snake_case, unused)]
+#[no_mangle]
+pub extern "C" fn SSL_use_certificate_ASN1(ssl: *mut SSL, d: *const c_uchar, len: c_int) -> c_int {
+    info!("SSL_use_certificate_ASN1");
+    return setup_attester_with_openssl_ssl_obj(ssl);
+}
+
+#[allow(non_snake_case, unused)]
+#[no_mangle]
+pub extern "C" fn SSL_use_certificate_file(
+    ssl: *mut SSL,
+    file: *const c_char,
+    type_: c_int,
+) -> c_int {
+    info!("SSL_use_certificate_file");
+    return setup_attester_with_openssl_ssl_obj(ssl);
+}
+
+#[allow(non_snake_case, unused)]
+#[no_mangle]
+pub extern "C" fn SSL_CTX_use_certificate_chain_file(
+    ctx: *mut SSL_CTX,
+    file: *const c_char,
+) -> c_int {
+    info!("SSL_CTX_use_certificate_chain_file");
+    return setup_attester_with_openssl_ssl_ctx_obj(ctx);
+}
+
+#[allow(non_snake_case, unused)]
+#[no_mangle]
+pub extern "C" fn SSL_use_certificate_chain_file(ssl: *mut SSL, file: *const c_char) -> c_int {
+    info!("SSL_use_certificate_chain_file");
+    return setup_attester_with_openssl_ssl_obj(ssl);
+}
+
+#[allow(non_snake_case, unused)]
+#[no_mangle]
+pub extern "C" fn SSL_CTX_use_PrivateKey(ctx: *mut SSL_CTX, pkey: *mut EVP_PKEY) -> c_int {
+    info!("SSL_CTX_use_PrivateKey");
+    return setup_attester_with_openssl_ssl_ctx_obj(ctx);
+}
+
+#[allow(non_snake_case, unused)]
+#[no_mangle]
+pub extern "C" fn SSL_CTX_use_PrivateKey_ASN1(
+    pk: c_int,
+    ctx: *mut SSL_CTX,
+    d: *const c_uchar,
+    len: c_long,
+) -> c_int {
+    info!("SSL_CTX_use_PrivateKey");
+    return setup_attester_with_openssl_ssl_ctx_obj(ctx);
+}
+
+#[allow(non_snake_case, unused)]
+#[no_mangle]
+pub extern "C" fn SSL_CTX_use_PrivateKey_file(
+    ctx: *mut SSL_CTX,
+    file: *const c_char,
+    type_: c_int,
+) -> c_int {
+    info!("SSL_CTX_use_PrivateKey_file");
+    return setup_attester_with_openssl_ssl_ctx_obj(ctx);
+}
+
+#[allow(non_snake_case, unused)]
+#[no_mangle]
+pub extern "C" fn SSL_CTX_use_RSAPrivateKey(ctx: *mut SSL_CTX, rsa: *mut RSA) -> c_int {
+    info!("SSL_CTX_use_RSAPrivateKey");
+    return setup_attester_with_openssl_ssl_ctx_obj(ctx);
+}
+
+#[allow(non_snake_case, unused)]
+#[no_mangle]
+pub extern "C" fn SSL_CTX_use_RSAPrivateKey_ASN1(
+    ctx: *mut SSL_CTX,
+    d: *const c_uchar,
+    len: c_long,
+) -> c_int {
+    info!("SSL_CTX_use_RSAPrivateKey_ASN1");
+    return setup_attester_with_openssl_ssl_ctx_obj(ctx);
+}
+
+#[allow(non_snake_case, unused)]
+#[no_mangle]
+pub extern "C" fn SSL_CTX_use_RSAPrivateKey_file(
+    ctx: *mut SSL_CTX,
+    file: *const c_char,
+    type_: c_int,
+) -> c_int {
+    info!("SSL_CTX_use_RSAPrivateKey_file");
+    return setup_attester_with_openssl_ssl_ctx_obj(ctx);
+}
+
+#[allow(non_snake_case, unused)]
+#[no_mangle]
+pub extern "C" fn SSL_use_PrivateKey(ssl: *mut SSL, pkey: *mut EVP_PKEY) -> c_int {
+    info!("SSL_use_PrivateKey");
+    return setup_attester_with_openssl_ssl_obj(ssl);
+}
+
+#[allow(non_snake_case, unused)]
+#[no_mangle]
+pub extern "C" fn SSL_use_PrivateKey_ASN1(
+    pk: c_int,
+    ssl: *mut SSL,
+    d: *const c_uchar,
+    len: c_long,
+) -> c_int {
+    info!("SSL_use_PrivateKey_ASN1");
+    return setup_attester_with_openssl_ssl_obj(ssl);
+}
+
+#[allow(non_snake_case, unused)]
+#[no_mangle]
+pub extern "C" fn SSL_use_PrivateKey_file(
+    ssl: *mut SSL,
+    file: *const c_char,
+    type_: c_int,
+) -> c_int {
+    info!("SSL_use_PrivateKey_file");
+    return setup_attester_with_openssl_ssl_obj(ssl);
+}
+
+#[allow(non_snake_case, unused)]
+#[no_mangle]
+pub extern "C" fn SSL_use_RSAPrivateKey(ssl: *mut SSL, rsa: *mut RSA) -> c_int {
+    info!("SSL_use_RSAPrivateKey");
+    return setup_attester_with_openssl_ssl_obj(ssl);
+}
+
+#[allow(non_snake_case, unused)]
+#[no_mangle]
+pub extern "C" fn SSL_use_RSAPrivateKey_ASN1(
+    ssl: *mut SSL,
+    d: *const c_uchar,
+    len: c_long,
+) -> c_int {
+    info!("SSL_use_RSAPrivateKey_ASN1");
+    return setup_attester_with_openssl_ssl_obj(ssl);
+}
+
+#[allow(non_snake_case, unused)]
+#[no_mangle]
+pub extern "C" fn SSL_use_RSAPrivateKey_file(
+    ssl: *mut SSL,
+    file: *const c_char,
+    type_: c_int,
+) -> c_int {
+    info!("SSL_use_RSAPrivateKey_file");
+    return setup_attester_with_openssl_ssl_obj(ssl);
+}
+
+#[allow(non_snake_case, unused)]
+#[no_mangle]
+pub extern "C" fn SSL_CTX_use_cert_and_key(
+    ctx: *mut SSL_CTX,
+    x509: *mut X509,
+    privatekey: *mut EVP_PKEY,
+    chain: *mut stack_st_X509,
+    override_: c_int,
+) -> c_int {
+    info!("SSL_CTX_use_cert_and_key");
+    return setup_attester_with_openssl_ssl_ctx_obj(ctx);
+}
+
+#[allow(non_snake_case, unused)]
+#[no_mangle]
+pub extern "C" fn SSL_use_cert_and_key(
+    ssl: *mut SSL,
+    x509: *mut X509,
+    privatekey: *mut EVP_PKEY,
+    chain: *mut stack_st_X509,
+    override_: c_int,
+) -> c_int {
+    info!("SSL_use_cert_and_key");
+    return setup_attester_with_openssl_ssl_obj(ssl);
+}
+
+#[allow(non_snake_case, unused)]
+#[no_mangle]
+pub extern "C" fn SSL_CTX_set_cert_verify_callback(
+    ctx: *mut SSL_CTX,
+    cb: ::std::option::Option<
+        unsafe extern "C" fn(arg1: *mut X509_STORE_CTX, arg2: *mut ::libc::c_void) -> ::libc::c_int,
+    >,
+    arg: *mut ::libc::c_void,
+) -> c_int {
+    info!("SSL_CTX_set_cert_verify_callback");
+    return setup_verifier_with_openssl_ssl_ctx_obj(ctx);
+}
+
+// Only setting `SSL_set_verify` or `SSL_CTX_set_veriy` as rats-rs certificate verify hook is not enough, since some openssl lib users(like curl) will use
+// `SSL_get_verify_result` to get certificate verify result, which is still produced by the default openssl cerfiticate verify function. we should provide
+// a entire certificate verify callback.
+// check https://docs.openssl.org/master/man3/SSL_CTX_set_cert_verify_callback/ for more information.
+#[no_mangle]
+pub extern "C" fn cert_verify_callback(ctx: *mut X509_STORE_CTX, _: *mut ::libc::c_void) -> c_int {
+    let ssl = unsafe {
+        X509_STORE_CTX_get_ex_data(ctx, SSL_get_ex_data_X509_STORE_CTX_idx()) as *mut SSL
+    };
+    let res = unsafe { X509_verify_cert(ctx) };
+    let err = unsafe { X509_STORE_CTX_get_error(ctx) };
+    // we tolerate self signed error
+    if err == X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT {
+        unsafe { X509_STORE_CTX_set_error(ctx, X509_V_OK) };
+        unsafe { SSL_set_verify_result(ssl, 0) };
+    }
+    return res;
+}
+
+pub enum OsslObject {
+    Ssl(*mut SSL),
+    SslCtx(*mut SSL_CTX),
+}
+
+pub fn setup_ssl_attester(obj: OsslObject) -> Result<()> {
+    let privkey = DefaultCrypto::gen_private_key(AsymmetricAlgo::Rsa2048)?;
+    let cert = CertBuilder::new(AutoAttester::new(), HashAlgo::Sha256)
+        .build_with_private_key(&privkey)?
+        .cert_to_der()?;
+    let epkey;
+    match &privkey {
+        rats_rs::crypto::AsymmetricPrivateKey::Rsa2048(_)
+        | rats_rs::crypto::AsymmetricPrivateKey::Rsa3072(_)
+        | rats_rs::crypto::AsymmetricPrivateKey::Rsa4096(_) => {
+            epkey = EVP_PKEY_RSA;
+        }
+        rats_rs::crypto::AsymmetricPrivateKey::P256(_) => {
+            epkey = EVP_PKEY_EC;
+        }
+    }
+    let pkey = privkey.to_pkcs8_der()?;
+    let pkey_len = pkey.as_bytes().len();
+    let pkey_buffer = pkey.as_bytes().as_ptr();
+
+    unsafe {
+        ERR_clear_error();
+    }
+    match obj {
+        OsslObject::Ssl(ssl) => {
+            let mut res = unsafe {
+                OSSL_CTX.ssl_use_certificate_asn1.unwrap()(ssl, cert.as_ptr(), cert.len() as c_int)
+            };
+            if res != 1 {
+                return Err(Error::msg(format!(
+                    "Failed to setup certificate: {}",
+                    unsafe {
+                        CStr::from_ptr(ERR_error_string(ERR_get_error(), null_mut())).to_str()?
+                    }
+                )));
+            }
+            res = unsafe {
+                OSSL_CTX.ssl_use_privatekey_asn1.unwrap()(
+                    epkey,
+                    ssl,
+                    pkey_buffer,
+                    pkey_len as c_long,
+                )
+            };
+            if res != 1 {
+                return Err(Error::msg(format!(
+                    "Failed to setup privatekey: {}",
+                    unsafe {
+                        CStr::from_ptr(ERR_error_string(ERR_get_error(), null_mut())).to_str()?
+                    }
+                )));
+            }
+        }
+        OsslObject::SslCtx(ctx) => {
+            let mut res = unsafe {
+                OSSL_CTX.ssl_ctx_use_certificate_asn1.unwrap()(
+                    ctx,
+                    cert.len() as c_int,
+                    cert.as_ptr(),
+                )
+            };
+            if res != 1 {
+                return Err(Error::msg(format!(
+                    "Failed to setup certificate: {}",
+                    unsafe {
+                        CStr::from_ptr(ERR_error_string(ERR_get_error(), null_mut())).to_str()?
+                    }
+                )));
+            }
+            res = unsafe {
+                OSSL_CTX.ssl_ctx_use_privatekey_asn1.unwrap()(
+                    epkey,
+                    ctx,
+                    pkey_buffer,
+                    pkey_len as c_long,
+                )
+            };
+            if res != 1 {
+                return Err(Error::msg(format!(
+                    "Failed to setup privatekey: {}",
+                    unsafe {
+                        CStr::from_ptr(ERR_error_string(ERR_get_error(), null_mut())).to_str()?
+                    }
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn setup_ssl_verifier(obj: OsslObject) -> Result<()> {
+    match obj {
+        OsslObject::Ssl(ssl) => {
+            let old_cb = unsafe { SSL_get_verify_callback(ssl) };
+            let ctx = unsafe { SSL_get_SSL_CTX(ssl) };
+            let cert_store = unsafe { SSL_CTX_get_cert_store(ctx) };
+            let verify_mode = unsafe { SSL_get_verify_mode(ssl) };
+            if old_cb.is_some() && old_cb.unwrap() == verify_certificate_default {
+                return Ok(());
+            }
+            unsafe {
+                X509_STORE_set_ex_data(cert_store, *OPENSSL_EX_DATA_IDX, ctx as *mut c_void);
+                OSSL_CTX.ssl_set_verify.unwrap()(
+                    ssl,
+                    verify_mode,
+                    Some(verify_certificate_default),
+                );
+                OSSL_CTX.ssl_ctx_set_cert_verify_callback.unwrap()(
+                    ctx,
+                    Some(cert_verify_callback),
+                    null_mut(),
+                );
+            }
+        }
+        OsslObject::SslCtx(ctx) => {
+            let old_cb = unsafe { SSL_CTX_get_verify_callback(ctx) };
+            let cert_store = unsafe { SSL_CTX_get_cert_store(ctx) };
+            let verify_mode = unsafe { SSL_CTX_get_verify_mode(ctx) };
+            if old_cb.is_some() && old_cb.unwrap() == verify_certificate_default {
+                return Ok(());
+            }
+            unsafe {
+                X509_STORE_set_ex_data(cert_store, *OPENSSL_EX_DATA_IDX, ctx as *mut c_void);
+                OSSL_CTX.ssl_ctx_set_verify.unwrap()(
+                    ctx,
+                    verify_mode,
+                    Some(verify_certificate_default),
+                );
+                OSSL_CTX.ssl_ctx_set_cert_verify_callback.unwrap()(
+                    ctx,
+                    Some(cert_verify_callback),
+                    null_mut(),
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+#[ctor]
+fn init() {
+    let env = env_logger::Env::default()
+        .filter_or("RATS_RS_LOG_LEVEL", "debug")
+        .write_style_or("RATS_RS_LOG_STYLE", "always");
+    env_logger::Builder::from_env(env).init();
+    if let Err(e) = ossl_init() {
+        error!("openssl init error: {:?}", e);
+    }
+}
+
+#[dtor]
+fn fini() {
+    info!("openssl-hook finish");
+}

--- a/examples/tls/Cargo.toml
+++ b/examples/tls/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "tls"
+edition.workspace = true
+version.workspace = true
+readme.workspace = true
+license.workspace = true
+
+[dependencies]
+rats-rs = {path = "../../rats-rs", features = ["is-sync"]}
+env_logger = {workspace = true}
+clap = {version = "4.5.4", features = ["derive"]}
+anyhow = {workspace = true}
+log = {workspace = true}
+rand = {version = "0.8.5", features = ["small_rng"]}

--- a/examples/tls/src/echo/mod.rs
+++ b/examples/tls/src/echo/mod.rs
@@ -1,0 +1,45 @@
+use crate::{
+    tls::{with_tls_tcp_client, with_tls_tcp_server},
+    CommonClientOptions, CommonServerOptions,
+};
+use anyhow::Result;
+use log::info;
+use rand::{rngs::SmallRng, RngCore, SeedableRng};
+use rats_rs::transport::{GenericSecureTransPortRead, GenericSecureTransPortWrite};
+
+pub fn echo_client(opts: CommonClientOptions) -> Result<()> {
+    with_tls_tcp_client(opts, |mut c| {
+        let mut rng = SmallRng::from_entropy();
+        for _i in 0..128 {
+            let mut expected = [0u8; 8];
+            let expected_len = expected.len();
+
+            rng.fill_bytes(&mut expected);
+            c.send(&expected)?;
+
+            let mut buffer = [0u8; 1024];
+            let recv_len = c.receive(&mut buffer[..expected_len])?;
+
+            assert_eq!(expected_len, recv_len);
+            assert_eq!(expected, buffer[..expected_len]);
+            info!("{}/128: passed", _i + 1);
+        }
+        c.shutdown()?;
+        Ok(())
+    })?;
+    Ok(())
+}
+
+pub fn echo_server(opts: CommonServerOptions) -> Result<()> {
+    with_tls_tcp_server(opts, |mut s| {
+        let mut buffer = [0u8; 1024];
+        let buffer_len = buffer.len();
+        for _i in 0..128 {
+            let recv_len = s.receive(&mut buffer[..buffer_len])?;
+            s.send(&mut buffer[..recv_len])?;
+        }
+        s.shutdown()?;
+        Ok(())
+    })?;
+    Ok(())
+}

--- a/examples/tls/src/main.rs
+++ b/examples/tls/src/main.rs
@@ -1,0 +1,86 @@
+mod echo;
+mod tls;
+
+use anyhow::Result;
+use clap::{arg, ArgAction, Parser};
+use echo::{echo_client, echo_server};
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+enum TlsCommand {
+    #[command(name = "echo-client")]
+    EchoClient(CommonClientOptions),
+    #[command(name = "echo-server")]
+    EchoServer(CommonServerOptions),
+}
+
+#[derive(Parser, Debug)]
+struct CommonServerOptions {
+    /// Whether to attest self to peer. Defaults to `true`.
+    #[arg(
+        long,
+        default_missing_value("true"),
+        default_value("true"),
+        num_args(0..=1),
+        require_equals(true),
+        action = ArgAction::Set,
+    )]
+    attest_self: bool,
+
+    /// Whether to verify peer. Defaults to `false`.
+    #[arg(
+        long,
+        default_missing_value("true"),
+        default_value("false"),
+        num_args(0..=1),
+        require_equals(true),
+        action = ArgAction::Set,
+    )]
+    verify_peer: bool,
+
+    /// The ip:port to listen on for TCP connections.
+    #[arg(long)]
+    listen_on_tcp: String,
+}
+
+#[derive(Parser, Debug, Clone)]
+struct CommonClientOptions {
+    /// Whether to attest self to peer. Defaults to `false`.
+    #[arg(
+        long,
+        default_missing_value("true"),
+        default_value("false"),
+        num_args(0..=1),
+        require_equals(true),
+        action = ArgAction::Set,
+    )]
+    attest_self: bool,
+
+    /// Whether to verify peer. Defaults to `true`.
+    #[arg(
+        long,
+        default_missing_value("true"),
+        default_value("true"),
+        num_args(0..=1),
+        require_equals(true),
+        action = ArgAction::Set,
+    )]
+    verify_peer: bool,
+
+    /// The ip:port to connect to for TCP connection.
+    #[arg(long)]
+    connect_to_tcp: String,
+}
+
+fn main() -> Result<()> {
+    let env = env_logger::Env::default()
+        .filter_or("RATS_RS_LOG_LEVEL", "debug")
+        .write_style_or("RATS_RS_LOG_STYLE", "always");
+    env_logger::Builder::from_env(env).init();
+    let command = TlsCommand::parse();
+    match command {
+        TlsCommand::EchoClient(opts) => echo_client(opts)?,
+        TlsCommand::EchoServer(opts) => echo_server(opts)?,
+    }
+    Ok(())
+}

--- a/examples/tls/src/tls.rs
+++ b/examples/tls/src/tls.rs
@@ -1,0 +1,78 @@
+use crate::{CommonClientOptions, CommonServerOptions};
+use anyhow::{bail, Result};
+use log::info;
+use rats_rs::transport::{
+    tls::{Client, Server, TlsClientBuilder, TlsServerBuilder},
+    GenericSecureTransPort,
+};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+
+pub fn with_tls_tcp_client(
+    opts: CommonClientOptions,
+    func: impl FnOnce(Client) -> Result<()>,
+) -> Result<()> {
+    let server_addr: SocketAddr = opts.connect_to_tcp.parse().expect("Invalid address");
+
+    // Connect to TCP server
+    let stream = TcpStream::connect(server_addr).expect("Failed to connect to server");
+
+    info!("Connected to server: {}", server_addr);
+
+    let mut client = TlsClientBuilder::new()
+        .with_attest_self(opts.attest_self)
+        .with_tcp_stream(stream)
+        .build()?;
+
+    client.negotiate()?;
+
+    info!(
+        "The tls session on connection {} (responder) is ready.",
+        server_addr
+    );
+
+    func(client)?;
+
+    info!("Everything is fine, exit now.");
+    Ok(())
+}
+
+pub fn with_tls_tcp_server(
+    opts: CommonServerOptions,
+    func: impl Fn(Server) -> Result<()>,
+) -> Result<()> {
+    let listen_addr: SocketAddr = opts.listen_on_tcp.parse().expect("Invalid address");
+
+    let listener = TcpListener::bind(listen_addr).expect("Failed to bind to address");
+
+    info!("Server started, listening on {}", listen_addr);
+
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                let peer_addr = stream.peer_addr().unwrap();
+                info!("New connection: {}", peer_addr);
+                let mut server = TlsServerBuilder::new()
+                    .with_verify_peer(opts.verify_peer)
+                    .with_tcp_stream(stream)
+                    .build()?;
+                server.negotiate()?;
+
+                info!(
+                    "The tls session on connection {} (requester) is ready.",
+                    peer_addr
+                );
+
+                func(server)?;
+
+                info!(
+                    "The connection {} is shutdown, waiting for another now.",
+                    peer_addr
+                );
+            }
+            Err(e) => {
+                bail!("Error accepting connection: {}", e);
+            }
+        }
+    }
+    Ok(())
+}

--- a/rats-rs/Cargo.toml
+++ b/rats-rs/Cargo.toml
@@ -31,7 +31,7 @@ spdmlib = {workspace = true, optional = true}
 spin = {workspace = true}
 thiserror = "1.0.56"
 tokio = {version = "1.36.0", features = ["full"], optional = true}
-x509-cert = {version = "0.2.5", features = ["builder"], optional = true}
+x509-cert = {version = "0.2.5", features = ["builder", "hazmat"], optional = true}
 zeroize = "1.7.0"
 bstr = "1.9.1"
 itertools = "0.12.1"

--- a/rats-rs/Cargo.toml
+++ b/rats-rs/Cargo.toml
@@ -38,13 +38,17 @@ itertools = "0.12.1"
 indexmap = {version = "2.2.6", features = ["std", "serde"]}
 tdx-attest-rs = {git = "https://github.com/intel/SGXDataCenterAttestationPrimitives", tag = "DCAP_1.20", optional = true}
 intel-dcap = {path = "../intel-dcap", optional = true}
+openssl-sys = {version = "0.9", optional = true, features = ["bindgen"] }
+libc = {version = "0.2", optional = true}
+lazy_static = "1.5.0"
 
 [features]
 async-tokio = ["dep:tokio"]
 crypto-rustcrypto = ["dep:x509-cert", "dep:sha2", "dep:p256", "dep:rsa", "dep:pkcs8", "dep:const-oid", "dep:signature"]
-default = ["crypto-rustcrypto", "transport-spdm", "attester-sgx-dcap-occlum", "verifier-sgx-dcap", "attester-tdx", "verifier-tdx", "is-sync"]
+default = ["crypto-rustcrypto", "transport-spdm", "attester-sgx-dcap-occlum", "verifier-sgx-dcap", "attester-tdx", "verifier-tdx", "is-sync", "transport-tls"]
 is-sync = ["maybe-async/is_sync", "spdmlib/is_sync"]
 transport-spdm = ["dep:spdmlib", "dep:codec", "dep:ring"]
+transport-tls = ["dep:openssl-sys", "dep:libc"]
 attester-sgx-dcap = ["dep:intel-dcap"]
 attester-sgx-dcap-occlum = ["attester-sgx-dcap", "dep:occlum_dcap"]
 attester-sgx-dcap-enclave = [] # TODO: plain enclave mode

--- a/rats-rs/src/cert/verify.rs
+++ b/rats-rs/src/cert/verify.rs
@@ -34,11 +34,11 @@ pub struct CertVerifier {
 
 #[allow(dead_code)]
 impl CertVerifier {
-    fn new(policy: VerifiyPolicy) -> Self {
+    pub(crate) fn new(policy: VerifiyPolicy) -> Self {
         Self { policy }
     }
 
-    fn verify(&self, cert: &[u8]) -> Result<VerifyPolicyOutput> {
+    pub(crate) fn verify(&self, cert: &[u8]) -> Result<VerifyPolicyOutput> {
         let claims = verify_cert_der(cert)?;
 
         let passed = match &self.policy {

--- a/rats-rs/src/crypto/mod.rs
+++ b/rats-rs/src/crypto/mod.rs
@@ -1,6 +1,6 @@
 use crate::errors::*;
 
-use pkcs8::{DecodePrivateKey, EncodePrivateKey, EncodePublicKey, LineEnding};
+use pkcs8::{DecodePrivateKey, EncodePrivateKey, EncodePublicKey, LineEnding, SecretDocument};
 use rsa::traits::PublicKeyParts;
 use sha2::Digest as _;
 use zeroize::Zeroizing;
@@ -37,6 +37,21 @@ impl AsymmetricPrivateKey {
             | AsymmetricPrivateKey::Rsa4096(key) => key.to_pkcs8_pem(LineEnding::LF)?,
             AsymmetricPrivateKey::P256(key) => key.to_pkcs8_pem(LineEnding::LF)?,
         })
+    }
+
+    pub fn to_pkcs8_der(&self) -> Result<SecretDocument> {
+        let pkey;
+        match self {
+            AsymmetricPrivateKey::Rsa2048(key)
+            | AsymmetricPrivateKey::Rsa3072(key)
+            | AsymmetricPrivateKey::Rsa4096(key) => {
+                pkey = key.to_pkcs8_der()?;
+            }
+            AsymmetricPrivateKey::P256(key) => {
+                pkey = key.to_pkcs8_der()?;
+            }
+        }
+        return Ok(pkey);
     }
 
     pub fn from_pkcs8_pem(private_key_pkcs8: &str) -> Result<Self> {

--- a/rats-rs/src/errors.rs
+++ b/rats-rs/src/errors.rs
@@ -64,6 +64,40 @@ pub enum ErrorKind {
 
     SpdmlibError,
 
+    OsslUnsupportedPkeyAlgo,
+
+    OsslCtxUninitialize,
+
+    OsslCtxInitializeFail,
+
+    OsslUsePrivKeyfail,
+
+    OsslUseCertfail,
+
+    OsslNoMem,
+
+    OsslSetFdFail,
+
+    OsslServerNegotiationFail,
+
+    OsslGetExtensionFail,
+
+    OsslClientNegotiationFail,
+
+    OsslFindX509ExFail,
+
+    OsslOIDErr,
+
+    OsslClientConnectFail,
+
+    OsslCtxOrSessionUninitialized,
+
+    OsslSendFail,
+
+    OsslReceiveFail,
+
+    OsslInitializeFail,
+
     Unknown,
 }
 

--- a/rats-rs/src/errors.rs
+++ b/rats-rs/src/errors.rs
@@ -64,6 +64,8 @@ pub enum ErrorKind {
 
     SpdmlibError,
 
+    OsslTlsBuilderStreamUnset,
+
     OsslUnsupportedPkeyAlgo,
 
     OsslCtxUninitialize,

--- a/rats-rs/src/lib.rs
+++ b/rats-rs/src/lib.rs
@@ -5,7 +5,7 @@
 #![allow(unused_imports)]
 
 pub mod cert;
-mod crypto;
+pub mod crypto;
 pub mod errors;
 pub mod tee;
 pub mod transport;

--- a/rats-rs/src/tee/mod.rs
+++ b/rats-rs/src/tee/mod.rs
@@ -77,12 +77,12 @@ impl AutoEvidence{
         raw_evidence: &[u8],
     ) -> Result<Self> {
         #[cfg(any(feature = "attester-sgx-dcap", feature = "verifier-sgx-dcap"))]
-        if let Some(res) = sgx_dcap::evidence::create_evidence_from_dice(cbor_tag, raw_evidence) {
-            return res.map(|res| Self(Box::new(res)));
+        if let Some(Ok(res)) = sgx_dcap::evidence::create_evidence_from_dice(cbor_tag, raw_evidence) {
+            return Ok(Self(Box::new(res)));
         }
         #[cfg(any(feature = "attester-tdx", feature = "verifier-tdx"))]
-        if let Some(res) = tdx::evidence::create_evidence_from_dice(cbor_tag, raw_evidence) {
-            return res.map(|res| Self(Box::new(res)));
+        if let Some(Ok(res)) = tdx::evidence::create_evidence_from_dice(cbor_tag, raw_evidence) {
+            return Ok(Self(Box::new(res)));
         }
         return Err(Error::kind_with_msg(
             ErrorKind::UnrecognizedEvidenceType,

--- a/rats-rs/src/transport/mod.rs
+++ b/rats-rs/src/transport/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "transport-spdm")]
 pub mod spdm;
 
+#[cfg(feature = "transport-tls")]
+pub mod tls;
+
 use crate::errors::*;
 use maybe_async::maybe_async;
 

--- a/rats-rs/src/transport/tls/client.rs
+++ b/rats-rs/src/transport/tls/client.rs
@@ -1,0 +1,353 @@
+use super::{
+    as_raw, as_raw_mut, ossl_init, verify_certificate_default, EpvPkey, GetFd, GetFdDumpImpl,
+    SslMode, TcpWrapper, OPENSSL_EX_DATA_IDX,
+};
+use crate::{
+    cert::{
+        create::CertBuilder,
+        dice::cbor::{parse_evidence_buffer_with_tag, OCBR_TAG_EVIDENCE_INTEL_TEE_QUOTE},
+    },
+    crypto::{AsymmetricPrivateKey, DefaultCrypto, HashAlgo},
+    errors::*,
+    tee::{
+        sgx_dcap::evidence, AutoAttester, AutoEvidence, AutoVerifier, GenericEvidence,
+        GenericVerifier,
+    },
+    transport::{GenericSecureTransPort, GenericSecureTransPortRead, GenericSecureTransPortWrite},
+};
+use lazy_static::lazy_static;
+use log::{debug, error};
+use maybe_async::maybe_async;
+use openssl_sys::*;
+use pkcs8::EncodePrivateKey;
+use std::{
+    cell::Cell,
+    ffi::c_int,
+    net::{TcpStream, ToSocketAddrs},
+    os::fd::AsRawFd,
+    ptr,
+    sync::{Arc, Mutex},
+};
+
+pub struct Client {
+    ctx: Option<*mut SSL_CTX>,
+    ssl_session: Option<*mut SSL>,
+    verify_callback: SSL_verify_cb,
+    stream: Box<dyn GetFd>,
+    attest_self: bool,
+}
+
+pub struct TlsClientBuilder {
+    verify: SSL_verify_cb,
+    stream: Box<dyn GetFd>,
+    attest_self: bool,
+}
+
+impl TlsClientBuilder {
+    pub fn build(self) -> Result<Client> {
+        let mut c = Client {
+            ctx: None,
+            ssl_session: None,
+            verify_callback: Some(self.verify.unwrap_or(verify_certificate_default)),
+            stream: self.stream,
+            attest_self: self.attest_self,
+        };
+        c.init()?;
+        Ok(c)
+    }
+    pub fn with_verify(mut self, verify: SSL_verify_cb) -> Self {
+        self.verify = verify;
+        self
+    }
+    pub fn with_tcp_stream(mut self, stream: TcpStream) -> Self {
+        self.stream = Box::new(TcpWrapper(stream));
+        self
+    }
+    pub fn with_attest_self(mut self, attest_self: bool) -> Self {
+        self.attest_self = attest_self;
+        self
+    }
+    pub fn new() -> Self {
+        Self {
+            verify: None,
+            stream: Box::new(GetFdDumpImpl {}),
+            attest_self: false,
+        }
+    }
+}
+
+#[maybe_async]
+impl GenericSecureTransPortWrite for Client {
+    async fn send(&mut self, bytes: &[u8]) -> Result<()> {
+        if self.ctx.is_none() || self.ssl_session.is_none() {
+            return Err(Error::kind(ErrorKind::OsslCtxOrSessionUninitialized));
+        }
+        let res = unsafe {
+            SSL_write(
+                self.ssl_session.unwrap(),
+                bytes.as_ptr() as *const libc::c_void,
+                bytes.len() as i32,
+            )
+        };
+        if res < 0 {
+            return Err(Error::kind(ErrorKind::OsslSendFail));
+        }
+        Ok(())
+    }
+
+    async fn shutdown(&mut self) -> Result<()> {
+        if let Some(ssl_session) = self.ssl_session {
+            unsafe {
+                SSL_shutdown(ssl_session);
+                SSL_free(ssl_session);
+            }
+        }
+        if let Some(ctx) = self.ctx {
+            unsafe {
+                SSL_CTX_free(ctx);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[maybe_async]
+impl GenericSecureTransPortRead for Client {
+    async fn receive(&mut self, buf: &mut [u8]) -> Result<usize> {
+        if self.ctx.is_none() || self.ssl_session.is_none() {
+            return Err(Error::kind(ErrorKind::OsslCtxOrSessionUninitialized));
+        }
+        let res = unsafe {
+            SSL_read(
+                self.ssl_session.unwrap(),
+                buf.as_mut_ptr() as *mut libc::c_void,
+                buf.len() as i32,
+            )
+        };
+        if res < 0 {
+            return Err(Error::kind(ErrorKind::OsslReceiveFail));
+        }
+        Ok(res as usize)
+    }
+}
+
+#[maybe_async]
+impl GenericSecureTransPort for Client {
+    async fn negotiate(&mut self) -> Result<()> {
+        let ctx = self
+            .ctx
+            .ok_or(Error::kind(ErrorKind::OsslCtxUninitialize))?;
+        if self.verify_callback.is_some() {
+            let mode = SslMode::SSL_VERIFY_PEER;
+            unsafe {
+                SSL_CTX_set_verify(ctx, mode.bits(), self.verify_callback);
+            }
+        }
+        let session = unsafe { SSL_new(ctx) };
+        if session.is_null() {
+            return Err(Error::kind(ErrorKind::OsslNoMem));
+        }
+        unsafe {
+            X509_STORE_set_ex_data(
+                SSL_CTX_get_cert_store(ctx),
+                OPENSSL_EX_DATA_IDX.lock().unwrap().get(),
+                as_raw_mut(self),
+            );
+        }
+        let res = unsafe { SSL_set_fd(session, self.stream.get_fd()) };
+        if res != 1 {
+            return Err(Error::kind(ErrorKind::OsslSetFdFail));
+        }
+        unsafe {
+            ERR_clear_error();
+        }
+        let err = unsafe { SSL_connect(session) };
+        if err != 1 {
+            error!("failed to negotiate {}, SSL_get_error(): {}", err, unsafe {
+                SSL_get_error(session, err)
+            });
+            return Err(Error::kind(ErrorKind::OsslServerNegotiationFail));
+        }
+        self.ssl_session = Some(session);
+        Ok(())
+    }
+}
+
+impl Client {
+    pub fn init(&mut self) -> Result<()> {
+        ossl_init()?;
+        let ctx = unsafe { SSL_CTX_new(TLS_client_method()) };
+        if ctx.is_null() {
+            return Err(Error::kind(ErrorKind::OsslCtxInitializeFail));
+        }
+        self.ctx = Some(ctx);
+        if self.attest_self {
+            let privkey = DefaultCrypto::gen_private_key(crate::crypto::AsymmetricAlgo::Rsa2048)?;
+            self.use_privkey(&privkey)?;
+            let cert = CertBuilder::new(AutoAttester::new(), HashAlgo::Sha256)
+                .build_with_private_key(&privkey)?
+                .cert_to_der()?;
+            self.use_cert(&cert)?;
+        }
+        Ok(())
+    }
+    pub fn use_privkey(&mut self, privkey: &AsymmetricPrivateKey) -> Result<()> {
+        let pkey;
+        let epkey: ::libc::c_int;
+        match privkey {
+            AsymmetricPrivateKey::Rsa2048(key)
+            | AsymmetricPrivateKey::Rsa3072(key)
+            | AsymmetricPrivateKey::Rsa4096(key) => {
+                pkey = key.to_pkcs8_der().map_err(|_e| Error::unknown())?;
+                epkey = EpvPkey::RSA.bits();
+            }
+            AsymmetricPrivateKey::P256(key) => {
+                pkey = key.to_pkcs8_der()?;
+                epkey = EpvPkey::EC.bits();
+            }
+        }
+        let ctx = self
+            .ctx
+            .ok_or(Error::kind(ErrorKind::OsslCtxUninitialize))?;
+        let pkey_len = pkey.as_bytes().len() as ::libc::c_long;
+        let pkey_buffer = as_raw(&pkey.as_bytes()[0]);
+        unsafe {
+            let res = SSL_CTX_use_PrivateKey_ASN1(epkey, ctx, pkey_buffer, pkey_len);
+            if res != 1 {
+                return Err(Error::kind(ErrorKind::OsslUsePrivKeyfail));
+            }
+        }
+        Ok(())
+    }
+    pub fn use_cert(&mut self, cert: &Vec<u8>) -> Result<()> {
+        let ctx = self
+            .ctx
+            .ok_or(Error::kind(ErrorKind::OsslCtxUninitialize))?;
+        let res = unsafe {
+            SSL_CTX_use_certificate_ASN1(
+                ctx,
+                cert.len() as ::libc::c_int,
+                cert.as_ptr() as usize as *const ::libc::c_uchar,
+            )
+        };
+        if res != 1 {
+            return Err(Error::kind(ErrorKind::OsslUseCertfail));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Client;
+    use crate::{
+        cert::create::CertBuilder,
+        crypto::{AsymmetricAlgo, DefaultCrypto, HashAlgo},
+        errors::*,
+        tee::{AutoAttester, AutoVerifier},
+        transport::{
+            tls::{as_raw, as_raw_mut, GetFdDumpImpl},
+            GenericSecureTransPortWrite,
+        },
+    };
+    use openssl_sys::*;
+    use std::{ptr, slice};
+
+    #[test]
+    fn test_client_init() -> Result<()> {
+        let mut c = Client {
+            ctx: None,
+            ssl_session: None,
+            verify_callback: None,
+            stream: Box::new(GetFdDumpImpl),
+            attest_self: false,
+        };
+        c.init()?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_client_shutdown() -> Result<()> {
+        let mut c = Client {
+            ctx: None,
+            ssl_session: None,
+            verify_callback: None,
+            stream: Box::new(GetFdDumpImpl),
+            attest_self: false,
+        };
+        c.init()?;
+        c.shutdown()?;
+        Ok(())
+    }
+
+    fn ossl_get_privkey(c: &mut Client) -> Vec<u8> {
+        let ssl_session = unsafe { SSL_new(c.ctx.unwrap()) };
+        let pkey = unsafe { SSL_get_privatekey(ssl_session) };
+        let bio = unsafe { BIO_new(BIO_s_mem()) };
+        let res = unsafe {
+            PEM_write_bio_PrivateKey(
+                bio,
+                pkey,
+                ptr::null(),
+                ptr::null_mut(),
+                0,
+                None,
+                ptr::null_mut(),
+            )
+        };
+        assert_ne!(res, 0);
+        let mut pem_data = ptr::null_mut::<i8>();
+        let pem_size = unsafe { BIO_get_mem_data(bio, as_raw_mut(&mut pem_data)) };
+        let now =
+            unsafe { slice::from_raw_parts(pem_data as *const u8, pem_size as usize).to_vec() };
+        unsafe {
+            SSL_shutdown(ssl_session);
+            SSL_free(ssl_session);
+        }
+        now
+    }
+
+    #[test]
+    fn test_client_use_key() -> Result<()> {
+        let mut c = Client {
+            ctx: None,
+            ssl_session: None,
+            verify_callback: None,
+            stream: Box::new(GetFdDumpImpl),
+            attest_self: false,
+        };
+        c.init()?;
+        let privkey = DefaultCrypto::gen_private_key(AsymmetricAlgo::Rsa2048)?;
+        let binding = privkey.to_pkcs8_pem()?;
+        let privpem = binding.as_bytes();
+        c.use_privkey(&privkey)?;
+        let now = ossl_get_privkey(&mut c);
+        assert_eq!(privpem, now);
+        c.shutdown()?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_client_use_cert() -> Result<()> {
+        let mut c = Client {
+            ctx: None,
+            ssl_session: None,
+            verify_callback: None,
+            stream: Box::new(GetFdDumpImpl),
+            attest_self: false,
+        };
+        c.init()?;
+        let privkey = DefaultCrypto::gen_private_key(AsymmetricAlgo::Rsa2048)?;
+        let cert = CertBuilder::new(AutoAttester::new(), HashAlgo::Sha256)
+            .build_with_private_key(&privkey)?
+            .cert_to_der()?;
+        c.use_cert(&cert)?;
+        let raw_cert = unsafe { SSL_CTX_get0_certificate(c.ctx.unwrap()) };
+        let mut raw_ptr = ptr::null_mut::<u8>();
+        let len = unsafe { i2d_X509(raw_cert, &mut raw_ptr as *mut *mut u8) };
+        let now = unsafe { slice::from_raw_parts(raw_ptr as *const u8, len as usize).to_vec() };
+        assert_eq!(cert, now);
+        c.shutdown()?;
+        Ok(())
+    }
+}

--- a/rats-rs/src/transport/tls/mod.rs
+++ b/rats-rs/src/transport/tls/mod.rs
@@ -32,7 +32,7 @@ use std::{
 };
 
 lazy_static! {
-    static ref OPENSSL_EX_DATA_IDX: i32 =
+    pub static ref OPENSSL_EX_DATA_IDX: i32 =
         unsafe { CRYPTO_get_ex_new_index(4, 0, ptr::null_mut(), None, None, None,) };
 }
 
@@ -106,7 +106,8 @@ pub fn ossl_init() -> Result<()> {
     Ok(())
 }
 
-extern "C" fn verify_certificate_default(
+#[no_mangle]
+pub extern "C" fn verify_certificate_default(
     preverify_ok: libc::c_int,
     ctx: *mut X509_STORE_CTX,
 ) -> libc::c_int {
@@ -114,6 +115,7 @@ extern "C" fn verify_certificate_default(
         debug!("preverify_ok is 0");
         let err = unsafe { X509_STORE_CTX_get_error(ctx) };
         if err == X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT {
+            debug!("enter here!");
             return 1;
         }
         error!("Failed on pre-verification due to {}\n", err);

--- a/rats-rs/src/transport/tls/mod.rs
+++ b/rats-rs/src/transport/tls/mod.rs
@@ -1,0 +1,168 @@
+mod client;
+mod server;
+
+use super::{Error, ErrorKind, Result};
+use crate::{
+    cert::{
+        dice::extensions::{OID_TCG_DICE_ENDORSEMENT_MANIFEST, OID_TCG_DICE_TAGGED_EVIDENCE},
+        verify::{
+            verify_cert_der, CertVerifier, VerifiyPolicy, VerifiyPolicy::Contains,
+            VerifyPolicyOutput,
+        },
+    },
+    tee::claims::Claims,
+};
+use bitflags::bitflags;
+pub use client::{Client, TlsClientBuilder};
+use lazy_static::lazy_static;
+use libc::c_int;
+use log::{debug, error};
+use openssl_sys::*;
+use pkcs8::ObjectIdentifier;
+pub use server::{Server, TlsServerBuilder};
+use std::{
+    cell::Cell,
+    net::TcpStream,
+    os::fd::AsRawFd,
+    ptr, slice,
+    sync::{Arc, Mutex, Once},
+};
+
+lazy_static! {
+    static ref OPENSSL_EX_DATA_IDX: Arc<Mutex<Cell<i32>>> = unsafe {
+        Arc::new(Mutex::new(Cell::new(CRYPTO_get_ex_new_index(
+            4,
+            0,
+            ptr::null_mut(),
+            None,
+            None,
+            None,
+        ))))
+    };
+}
+
+static START: Once = Once::new();
+
+trait GetFd {
+    fn get_fd(&self) -> i32;
+}
+
+struct GetFdDumpImpl;
+
+impl GetFd for GetFdDumpImpl {
+    fn get_fd(&self) -> i32 {
+        0
+    }
+}
+
+struct TcpWrapper(TcpStream);
+
+impl GetFd for TcpWrapper {
+    fn get_fd(&self) -> i32 {
+        self.0.as_raw_fd()
+    }
+}
+
+#[inline]
+pub fn as_raw_mut<F, T>(p: &mut F) -> *mut T {
+    p as *mut F as usize as *mut T
+}
+
+#[inline]
+pub fn as_raw<F, T>(p: &F) -> *const T {
+    p as *const F as usize as *const T
+}
+
+bitflags! {
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    struct SslMode : i32 {
+        const SSL_VERIFY_NONE                 = 0x00;
+        const SSL_VERIFY_PEER                 = 0x01;
+        const SSL_VERIFY_FAIL_IF_NO_PEER_CERT = 0x02;
+        const SSL_VERIFY_CLIENT_ONCE          = 0x04;
+        const SSL_VERIFY_POST_HANDSHAKE       = 0x08;
+    }
+
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    struct SslInit : u64 {
+        const LOAD_CRYPTO_STRINGS = 0x0000_0002;
+        const ADD_ALL_CIPHERS = 0x0000_0004;
+        const ADD_ALL_DIGESTS = 0x0000_0008;
+        const LOAD_SSL_STRINGS = 0x0020_0000;
+    }
+
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    struct EpvPkey : i32 {
+        const EC = 408;
+        const RSA = 6;
+    }
+}
+
+pub fn ossl_init() -> Result<()> {
+    START.call_once(|| unsafe {
+        OPENSSL_init_crypto(
+            SslInit::ADD_ALL_DIGESTS.bits() | SslInit::ADD_ALL_DIGESTS.bits(),
+            ptr::null(),
+        );
+        OPENSSL_init_ssl(
+            SslInit::LOAD_SSL_STRINGS.bits() | SslInit::LOAD_CRYPTO_STRINGS.bits(),
+            ptr::null(),
+        );
+        OPENSSL_init_crypto(SslInit::LOAD_CRYPTO_STRINGS.bits(), ptr::null());
+        OPENSSL_init_crypto(SslInit::ADD_ALL_DIGESTS.bits(), ptr::null());
+    });
+    if unsafe { OPENSSL_init_ssl(0, ptr::null()) } < 0 {
+        return Err(Error::kind(ErrorKind::OsslInitializeFail));
+    }
+    Ok(())
+}
+
+extern "C" fn verify_certificate_default(
+    preverify_ok: libc::c_int,
+    ctx: *mut X509_STORE_CTX,
+) -> libc::c_int {
+    if preverify_ok == 0 {
+        debug!("preverify_ok is 0");
+        let err = unsafe { X509_STORE_CTX_get_error(ctx) };
+        if err == X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT {
+            return 1;
+        }
+        error!("Failed on pre-verification due to {}\n", err);
+        if err == X509_V_ERR_CERT_NOT_YET_VALID {
+            error!(
+                "Please ensure check the time-keeping is consistent between client and server\n"
+            );
+        }
+        return 0;
+    }
+    let raw_cert = unsafe { X509_STORE_CTX_get_current_cert(ctx) };
+    let mut raw_ptr = ptr::null_mut::<u8>();
+    let len = unsafe { i2d_X509(raw_cert, &mut raw_ptr as *mut *mut u8) };
+    let now = unsafe { slice::from_raw_parts(raw_ptr as *const u8, len as usize) };
+    let res = CertVerifier::new(Contains(Claims::new())).verify(now);
+    match res {
+        Ok(VerifyPolicyOutput::Passed) => {
+            return 1;
+        }
+        Ok(VerifyPolicyOutput::Failed) => {
+            error!("Verify failed because of claims");
+            return 0;
+        }
+        Err(err) => {
+            error!("Verify failed with err: {:?}", err);
+            return 0;
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::ossl_init;
+    use crate::errors::*;
+
+    #[test]
+    fn test_ossl_init() -> Result<()> {
+        ossl_init()?;
+        Ok(())
+    }
+}

--- a/rats-rs/src/transport/tls/server.rs
+++ b/rats-rs/src/transport/tls/server.rs
@@ -1,0 +1,367 @@
+use super::{
+    as_raw, as_raw_mut, ossl_init, verify_certificate_default, EpvPkey, GetFd, GetFdDumpImpl,
+    SslMode, TcpWrapper, OPENSSL_EX_DATA_IDX,
+};
+use crate::{
+    cert::{create::CertBuilder, dice::cbor::parse_evidence_buffer_with_tag},
+    crypto::{AsymmetricPrivateKey, DefaultCrypto, HashAlgo},
+    errors::*,
+    tee::{sgx_dcap::evidence, AutoAttester, GenericVerifier},
+    transport::{GenericSecureTransPort, GenericSecureTransPortRead, GenericSecureTransPortWrite},
+};
+use lazy_static::lazy_static;
+use log::{debug, error};
+use maybe_async::maybe_async;
+use openssl_sys::*;
+use pkcs8::EncodePrivateKey;
+use std::{
+    cell::Cell,
+    ffi::c_int,
+    io::{Read, Write},
+    net::{TcpStream, ToSocketAddrs},
+    os::fd::AsRawFd,
+    ptr,
+    sync::{Arc, Mutex},
+};
+
+//TODO: use typestate only impl `VerifyCertExtension` if needed
+pub struct Server {
+    ctx: Option<*mut SSL_CTX>,
+    ssl_session: Option<*mut SSL>,
+    verify_callback: SSL_verify_cb,
+    stream: Box<dyn GetFd>,
+}
+
+// TODO: use typestate design pattern?
+pub struct TlsServerBuilder {
+    verify: SSL_verify_cb,
+    stream: Box<dyn GetFd>,
+    verify_peer: bool,
+}
+
+impl TlsServerBuilder {
+    pub fn build(self) -> Result<Server> {
+        let mut s = Server {
+            ctx: None,
+            ssl_session: None,
+            verify_callback: if self.verify_peer {
+                if self.verify.is_some() {
+                    self.verify
+                } else {
+                    Some(verify_certificate_default)
+                }
+            } else {
+                None
+            },
+            stream: self.stream,
+        };
+        s.init()?;
+        Ok(s)
+    }
+    pub fn new() -> Self {
+        Self {
+            verify: None,
+            stream: Box::new(GetFdDumpImpl),
+            verify_peer: false,
+        }
+    }
+    pub fn with_verify(mut self, verify: SSL_verify_cb) -> Self {
+        self.verify = verify;
+        self
+    }
+    pub fn with_verify_peer(mut self, verify_peer: bool) -> Self {
+        self.verify_peer = verify_peer;
+        self
+    }
+    pub fn with_tcp_stream(mut self, stream: TcpStream) -> Self {
+        self.stream = Box::new(TcpWrapper(stream));
+        self
+    }
+}
+
+#[maybe_async]
+impl GenericSecureTransPortWrite for Server {
+    async fn send(&mut self, bytes: &[u8]) -> Result<()> {
+        if self.ctx.is_none() || self.ssl_session.is_none() {
+            return Err(Error::kind(ErrorKind::OsslCtxOrSessionUninitialized));
+        }
+        let res = unsafe {
+            SSL_write(
+                self.ssl_session.unwrap(),
+                bytes.as_ptr() as *const libc::c_void,
+                bytes.len() as i32,
+            )
+        };
+        if res < 0 {
+            return Err(Error::kind(ErrorKind::OsslSendFail));
+        }
+        Ok(())
+    }
+
+    async fn shutdown(&mut self) -> Result<()> {
+        if let Some(ssl_session) = self.ssl_session {
+            unsafe {
+                SSL_shutdown(ssl_session);
+                SSL_free(ssl_session);
+            }
+        }
+        if let Some(ctx) = self.ctx {
+            unsafe {
+                SSL_CTX_free(ctx);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[maybe_async]
+impl GenericSecureTransPortRead for Server {
+    async fn receive(&mut self, buf: &mut [u8]) -> Result<usize> {
+        if self.ctx.is_none() || self.ssl_session.is_none() {
+            return Err(Error::kind(ErrorKind::OsslCtxOrSessionUninitialized));
+        }
+        let res = unsafe {
+            SSL_read(
+                self.ssl_session.unwrap(),
+                buf.as_mut_ptr() as *mut libc::c_void,
+                buf.len() as i32,
+            )
+        };
+        if res < 0 {
+            return Err(Error::kind(ErrorKind::OsslReceiveFail));
+        }
+        Ok(res as usize)
+    }
+}
+
+#[maybe_async]
+impl GenericSecureTransPort for Server {
+    async fn negotiate(&mut self) -> Result<()> {
+        let ctx = self
+            .ctx
+            .ok_or(Error::kind(ErrorKind::OsslCtxUninitialize))?;
+        if self.verify_callback.is_some() {
+            let mut mode = SslMode::SSL_VERIFY_NONE;
+            mode |= SslMode::SSL_VERIFY_PEER | SslMode::SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
+            unsafe {
+                SSL_CTX_set_verify(ctx, mode.bits(), self.verify_callback);
+            }
+        }
+        let session = unsafe { SSL_new(ctx) };
+        if session.is_null() {
+            return Err(Error::kind(ErrorKind::OsslNoMem));
+        }
+        unsafe {
+            X509_STORE_set_ex_data(
+                SSL_CTX_get_cert_store(ctx),
+                OPENSSL_EX_DATA_IDX.lock().unwrap().get(),
+                as_raw_mut(self),
+            );
+        }
+        let res = unsafe { SSL_set_fd(session, self.stream.get_fd()) };
+        if res != 1 {
+            return Err(Error::kind(ErrorKind::OsslSetFdFail));
+        }
+        unsafe {
+            ERR_clear_error();
+        }
+        let err = unsafe { SSL_accept(session) };
+        if err != 1 {
+            error!("failed to negotiate {}, SSL_get_error(): {}", err, unsafe {
+                SSL_get_error(session, err)
+            });
+            return Err(Error::kind(ErrorKind::OsslServerNegotiationFail));
+        }
+        self.ssl_session = Some(session);
+        Ok(())
+    }
+}
+
+impl Server {
+    pub fn init(&mut self) -> Result<()> {
+        ossl_init()?;
+        let ctx = unsafe { SSL_CTX_new(TLS_server_method()) };
+        if ctx.is_null() {
+            return Err(Error::kind(ErrorKind::OsslCtxInitializeFail));
+        }
+        self.ctx = Some(ctx);
+        let privkey = DefaultCrypto::gen_private_key(crate::crypto::AsymmetricAlgo::Rsa2048)?;
+        self.use_privkey(&privkey)?;
+        let cert = CertBuilder::new(AutoAttester::new(), HashAlgo::Sha256)
+            .build_with_private_key(&privkey)?
+            .cert_to_der()?;
+        self.use_cert(&cert)?;
+        Ok(())
+    }
+
+    pub fn use_privkey(&mut self, privkey: &AsymmetricPrivateKey) -> Result<()> {
+        let pkey;
+        let epkey: ::libc::c_int;
+        match privkey {
+            AsymmetricPrivateKey::Rsa2048(key)
+            | AsymmetricPrivateKey::Rsa3072(key)
+            | AsymmetricPrivateKey::Rsa4096(key) => {
+                pkey = key.to_pkcs8_der()?;
+                epkey = EpvPkey::RSA.bits();
+            }
+            AsymmetricPrivateKey::P256(key) => {
+                pkey = key.to_pkcs8_der()?;
+                epkey = EpvPkey::EC.bits();
+            }
+        }
+        let ctx = self
+            .ctx
+            .ok_or(Error::kind(ErrorKind::OsslCtxUninitialize))?;
+        let pkey_len = pkey.as_bytes().len() as ::libc::c_long;
+        let pkey_buffer = as_raw(&pkey.as_bytes()[0]);
+        unsafe {
+            let res = SSL_CTX_use_PrivateKey_ASN1(epkey, ctx, pkey_buffer, pkey_len);
+            if res != 1 {
+                return Err(Error::kind(ErrorKind::OsslUsePrivKeyfail));
+            }
+        }
+        Ok(())
+    }
+
+    pub fn use_cert(&mut self, cert: &Vec<u8>) -> Result<()> {
+        let ctx = self
+            .ctx
+            .ok_or(Error::kind(ErrorKind::OsslCtxUninitialize))?;
+        let ptr = cert.as_ptr();
+        let len = cert.len();
+        let res = unsafe {
+            SSL_CTX_use_certificate_ASN1(
+                ctx,
+                len as ::libc::c_int,
+                ptr as usize as *const ::libc::c_uchar,
+            )
+        };
+        if res != 1 {
+            return Err(Error::kind(ErrorKind::OsslUseCertfail));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Server;
+    use crate::{
+        cert::create::{CertBuilder, CertBundle},
+        crypto::{AsymmetricAlgo, DefaultCrypto, HashAlgo},
+        errors::*,
+        tee::AutoAttester,
+        transport::{
+            tls::{as_raw_mut, ossl_init, GetFdDumpImpl},
+            GenericSecureTransPortWrite,
+        },
+    };
+    use core::slice;
+    use openssl_sys::*;
+    use std::ptr;
+
+    #[test]
+    fn test_server_init() -> Result<()> {
+        let mut s = Server {
+            ctx: None,
+            ssl_session: None,
+            verify_callback: None,
+            stream: Box::new(GetFdDumpImpl),
+        };
+        s.init()?;
+        s.shutdown()?;
+        Ok(())
+    }
+    #[test]
+    fn test_server_shutdown() -> Result<()> {
+        let mut s = Server {
+            ctx: None,
+            ssl_session: None,
+            verify_callback: None,
+            stream: Box::new(GetFdDumpImpl),
+        };
+        s.init()?;
+        s.shutdown()?;
+        Ok(())
+    }
+
+    fn ossl_get_privkey(s: &mut Server) -> Vec<u8> {
+        let ssl_session = unsafe { SSL_new(s.ctx.unwrap()) };
+        let pkey = unsafe { SSL_get_privatekey(ssl_session) };
+        let bio = unsafe { BIO_new(BIO_s_mem()) };
+        let res = unsafe {
+            PEM_write_bio_PrivateKey(
+                bio,
+                pkey,
+                ptr::null(),
+                ptr::null_mut(),
+                0,
+                None,
+                ptr::null_mut(),
+            )
+        };
+        assert_ne!(res, 0);
+        let mut pem_data = ptr::null_mut::<i8>();
+        let pem_size = unsafe { BIO_get_mem_data(bio, as_raw_mut(&mut pem_data)) };
+        let now =
+            unsafe { slice::from_raw_parts(pem_data as *const u8, pem_size as usize).to_vec() };
+        unsafe {
+            SSL_shutdown(ssl_session);
+            SSL_free(ssl_session);
+        }
+        now
+    }
+
+    #[test]
+    fn test_server_use_key() -> Result<()> {
+        let mut s = Server {
+            ctx: None,
+            ssl_session: None,
+            verify_callback: None,
+            stream: Box::new(GetFdDumpImpl),
+        };
+        ossl_init()?;
+        let ctx = unsafe { SSL_CTX_new(TLS_server_method()) };
+        if ctx.is_null() {
+            return Err(Error::kind(ErrorKind::OsslCtxInitializeFail));
+        }
+        s.ctx = Some(ctx);
+        let privkey = DefaultCrypto::gen_private_key(AsymmetricAlgo::Rsa2048)?;
+        let binding = privkey.to_pkcs8_pem()?;
+        let privpem = binding.as_bytes();
+        s.use_privkey(&privkey)?;
+        let now = ossl_get_privkey(&mut s);
+        assert_eq!(privpem, now.as_slice());
+        s.shutdown()?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_server_use_cert() -> Result<()> {
+        let mut s = Server {
+            ctx: None,
+            ssl_session: None,
+            verify_callback: None,
+            stream: Box::new(GetFdDumpImpl),
+        };
+        ossl_init()?;
+        let ctx = unsafe { SSL_CTX_new(TLS_server_method()) };
+        if ctx.is_null() {
+            return Err(Error::kind(ErrorKind::OsslCtxInitializeFail));
+        }
+        s.ctx = Some(ctx);
+        let privkey = DefaultCrypto::gen_private_key(AsymmetricAlgo::Rsa2048)?;
+        let bundle = CertBuilder::new(AutoAttester::new(), HashAlgo::Sha256)
+            .build_with_private_key(&privkey)?;
+        let cert = bundle.cert_to_der()?;
+        println!("cert.pem: {}", bundle.cert_to_pem()?);
+        s.use_cert(&cert)?;
+        let raw_cert = unsafe { SSL_CTX_get0_certificate(s.ctx.unwrap()) };
+        let mut raw_ptr = ptr::null_mut::<u8>();
+        let len = unsafe { i2d_X509(raw_cert, &mut raw_ptr as *mut *mut u8) };
+        let now = unsafe { slice::from_raw_parts(raw_ptr as *const u8, len as usize).to_vec() };
+        assert_eq!(cert, now);
+        s.shutdown()?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
This pr contains an example about hooking openssl lib used in other executables, replace it with `rats-rs` verify logic, support `rats-rs` anywhere use openssl lib, Please check `README.md` in this pr for more information.